### PR TITLE
fix: make toKByteArray and toKLongArray return non-null

### DIFF
--- a/e2e/src/commonMain/kotlin/kni/test/CommonCallable.kt
+++ b/e2e/src/commonMain/kotlin/kni/test/CommonCallable.kt
@@ -13,6 +13,30 @@ expect object CommonCallable {
     fun fillBuffer(buffer: ByteBuffer): String
 
     @JniCall
+    fun longArray(value: LongArray): LongArray
+
+    @JniCall
+    fun byteArray(value: ByteArray): ByteArray
+
+    @JniCall
+    fun shortArray(value: ShortArray): ShortArray
+
+    @JniCall
+    fun booleanArray(value: BooleanArray): BooleanArray
+
+    @JniCall
+    fun charArray(value: CharArray): CharArray
+
+    @JniCall
+    fun doubleArray(value: DoubleArray): DoubleArray
+
+    @JniCall
+    fun floatArray(value: FloatArray): FloatArray
+
+    @JniCall
+    fun intArray(value: IntArray): IntArray
+
+    @JniCall
     fun anyIsNull(
         str: String? = "",
         i: Int? = 1,

--- a/e2e/src/jniJvmTest/kotlin/kni/test/bridgeTests.kt
+++ b/e2e/src/jniJvmTest/kotlin/kni/test/bridgeTests.kt
@@ -43,6 +43,46 @@ fun TestSuiteScope.bridgeTests() {
         val contents = buffer.readToByteArray(0, 1024)
         contents.toHexString() shouldBe filledHex
     }
+    test("LongArray parameter and return value") {
+        val value = longArrayOf(-2, 0, 1, 42)
+
+        CommonCallable.longArray(value).contentEquals(longArrayOf(-4, 0, 2, 84)) shouldBe true
+    }
+    test("ByteArray parameter and return value") {
+        val value = byteArrayOf(-128, -1, 0, 1, 127)
+
+        CommonCallable.byteArray(value).contentEquals(byteArrayOf(127, 1, 0, -1, -128)) shouldBe true
+    }
+    test("ShortArray parameter and return value") {
+        val value = shortArrayOf(-128, -1, 0, 1, 127)
+
+        CommonCallable.shortArray(value).contentEquals(shortArrayOf(127, 1, 0, -1, -128)) shouldBe true
+    }
+    test("BooleanArray parameter and return value") {
+        val value = booleanArrayOf(true, false, false, true)
+
+        CommonCallable.booleanArray(value).contentEquals(booleanArrayOf(true, false, false, true)) shouldBe true
+    }
+    test("CharArray parameter and return value") {
+        val value = charArrayOf('a', 'b', 'c', 'd')
+
+        CommonCallable.charArray(value).contentEquals(charArrayOf('d', 'c', 'b', 'a')) shouldBe true
+    }
+    test("DoubleArray parameter and return value") {
+        val value = doubleArrayOf(-2.5, 0.0, 1.25, 42.0)
+
+        CommonCallable.doubleArray(value).contentEquals(doubleArrayOf(-5.0, 0.0, 2.5, 84.0)) shouldBe true
+    }
+    test("FloatArray parameter and return value") {
+        val value = floatArrayOf(-2.5f, 0f, 1.25f, 42f)
+
+        CommonCallable.floatArray(value).contentEquals(floatArrayOf(-5f, 0f, 2.5f, 84f)) shouldBe true
+    }
+    test("IntArray parameter and return value") {
+        val value = intArrayOf(-2, 0, 1, 42)
+
+        CommonCallable.intArray(value).contentEquals(intArrayOf(-4, 0, 2, 84)) shouldBe true
+    }
     test("top-level") {
         topLevelFun().capacity shouldBe 1024
     }

--- a/e2e/src/jniNativeMain/kotlin/kni/test/CommonCallable.jniNative.kt
+++ b/e2e/src/jniNativeMain/kotlin/kni/test/CommonCallable.jniNative.kt
@@ -20,6 +20,46 @@ actual object CommonCallable {
     }
 
     @JniCall
+    actual fun longArray(value: LongArray): LongArray {
+        return value.map { it * 2 }.toLongArray()
+    }
+
+    @JniCall
+    actual fun byteArray(value: ByteArray): ByteArray {
+        return value.reversedArray()
+    }
+
+    @JniCall
+    actual fun shortArray(value: ShortArray): ShortArray {
+        return value.reversedArray()
+    }
+
+    @JniCall
+    actual fun booleanArray(value: BooleanArray): BooleanArray {
+        return value.reversedArray()
+    }
+
+    @JniCall
+    actual fun charArray(value: CharArray): CharArray {
+        return value.reversedArray()
+    }
+
+    @JniCall
+    actual fun doubleArray(value: DoubleArray): DoubleArray {
+        return value.map { it * 2 }.toDoubleArray()
+    }
+
+    @JniCall
+    actual fun floatArray(value: FloatArray): FloatArray {
+        return value.map { it * 2 }.toFloatArray()
+    }
+
+    @JniCall
+    actual fun intArray(value: IntArray): IntArray {
+        return value.map { it * 2 }.toIntArray()
+    }
+
+    @JniCall
     actual fun anyIsNull(
         str: String?,
         i: Int?,

--- a/jni/src/nativeMain/kotlin/com/dshatz/kni/utils/DoubleUtils.kt
+++ b/jni/src/nativeMain/kotlin/com/dshatz/kni/utils/DoubleUtils.kt
@@ -63,6 +63,6 @@ fun jdoubleArray.fill(env: CPointer<JNIEnvVar>, value: DoubleArray): jdoubleArra
 }
 
 @OptIn(ExperimentalForeignApi::class)
-fun DoubleArray.toJDoubleArray(env: CPointer<JNIEnvVar>): jdoubleArray? {
+fun DoubleArray.toJDoubleArray(env: CPointer<JNIEnvVar>): jdoubleArray {
     return env.newDoubleArray(size).fill(env, this)
 }

--- a/jni/src/nativeMain/kotlin/com/dshatz/kni/utils/IntUtils.kt
+++ b/jni/src/nativeMain/kotlin/com/dshatz/kni/utils/IntUtils.kt
@@ -47,14 +47,14 @@ fun jintArray.toKIntArray(env: CPointer<JNIEnvVar>): IntArray {
 }
 
 @OptIn(ExperimentalForeignApi::class)
-fun CPointer<JNIEnvVar>.newIntArray(size: jsize): jintArray? {
-    val method = pointed.pointedCommon?.NewIntArray ?: return null
-    return method.invoke(this, size)
+fun CPointer<JNIEnvVar>.newIntArray(size: jsize): jintArray {
+    val method = pointed.pointedCommon?.NewIntArray ?: throw JniUnavailableError()
+    return method.invoke(this, size) ?: throw OutOfMemoryError("Failed to allocate JVM int array of size $size")
 }
 
 @OptIn(ExperimentalForeignApi::class)
-fun jintArray.fill(env: CPointer<JNIEnvVar>, value: IntArray): jintArray? {
-    val method = env.pointed.pointedCommon?.SetIntArrayRegion ?: return null
+fun jintArray.fill(env: CPointer<JNIEnvVar>, value: IntArray): jintArray {
+    val method = env.pointed.pointedCommon?.SetIntArrayRegion ?: throw JniUnavailableError()
     value.usePinned { pinnedArray ->
         val pointer = pinnedArray.addressOf(0)
         method.invoke(env, this, 0, value.size, pointer)
@@ -63,6 +63,6 @@ fun jintArray.fill(env: CPointer<JNIEnvVar>, value: IntArray): jintArray? {
 }
 
 @OptIn(ExperimentalForeignApi::class)
-fun IntArray.toJIntArray(env: CPointer<JNIEnvVar>): jintArray? {
-    return env.newIntArray(size)?.fill(env, this)
+fun IntArray.toJIntArray(env: CPointer<JNIEnvVar>): jintArray {
+    return env.newIntArray(size).fill(env, this)
 }

--- a/jni/src/nativeMain/kotlin/com/dshatz/kni/utils/LongUtils.kt
+++ b/jni/src/nativeMain/kotlin/com/dshatz/kni/utils/LongUtils.kt
@@ -7,6 +7,7 @@ import com.dshatz.kni.binding.jlongArray
 import com.dshatz.kni.binding.jlongVar
 import com.dshatz.kni.binding.jint
 import com.dshatz.kni.binding.jsize
+import com.dshatz.kni.error.JniUnavailableError
 import com.dshatz.kni.pointedCommon
 import kotlinx.cinterop.CPointer
 import kotlinx.cinterop.ExperimentalForeignApi
@@ -19,9 +20,9 @@ import kotlinx.cinterop.usePinned
 
 @OptIn(ExperimentalForeignApi::class)
 @RequiresRelease
-fun jlongArray.getLongElements(env: CPointer<JNIEnvVar>, isCopy: CPointer<jbooleanVar>? = null): CPointer<jlongVar>? {
-    val method = env.pointed.pointedCommon?.GetLongArrayElements ?: return null
-    return method.invoke(env, this, isCopy)
+fun jlongArray.getLongElements(env: CPointer<JNIEnvVar>, isCopy: CPointer<jbooleanVar>? = null): CPointer<jlongVar> {
+    val method = env.pointed.pointedCommon?.GetLongArrayElements ?: throw JniUnavailableError()
+    return method.invoke(env, this, isCopy) ?: throw OutOfMemoryError("Failed to call GetLongArrayElements")
 }
 
 @OptIn(ExperimentalForeignApi::class)
@@ -31,9 +32,9 @@ fun jlongArray.releaseElements(env: CPointer<JNIEnvVar>, elements: CPointer<jlon
 }
 
 @OptIn(ExperimentalForeignApi::class, RequiresRelease::class)
-fun jlongArray.toKLongArray(env: CPointer<JNIEnvVar>): LongArray? {
-    val length = this.getLength(env) ?: return null
-    val elements = this.getLongElements(env) ?: return null
+fun jlongArray.toKLongArray(env: CPointer<JNIEnvVar>): LongArray {
+    val length = this.getLength(env)
+    val elements = this.getLongElements(env)
 
     val result = memScoped {
         LongArray(length) {

--- a/jni/src/nativeMain/kotlin/com/dshatz/kni/utils/LongUtils.kt
+++ b/jni/src/nativeMain/kotlin/com/dshatz/kni/utils/LongUtils.kt
@@ -47,14 +47,14 @@ fun jlongArray.toKLongArray(env: CPointer<JNIEnvVar>): LongArray {
 }
 
 @OptIn(ExperimentalForeignApi::class)
-fun CPointer<JNIEnvVar>.newLongArray(size: jsize): jlongArray? {
-    val method = pointed.pointedCommon?.NewLongArray ?: return null
-    return method.invoke(this, size)
+fun CPointer<JNIEnvVar>.newLongArray(size: jsize): jlongArray {
+    val method = pointed.pointedCommon?.NewLongArray ?: throw JniUnavailableError()
+    return method.invoke(this, size) ?: throw OutOfMemoryError("Failed to allocate JVM long array of size $size")
 }
 
 @OptIn(ExperimentalForeignApi::class)
-fun jlongArray.fill(env: CPointer<JNIEnvVar>, value: LongArray): jlongArray? {
-    val method = env.pointed.pointedCommon?.SetLongArrayRegion ?: return null
+fun jlongArray.fill(env: CPointer<JNIEnvVar>, value: LongArray): jlongArray {
+    val method = env.pointed.pointedCommon?.SetLongArrayRegion ?: throw JniUnavailableError()
     value.usePinned {
         val pointer = it.addressOf(0)
         method.invoke(env, this, 0, value.size, pointer)
@@ -63,6 +63,6 @@ fun jlongArray.fill(env: CPointer<JNIEnvVar>, value: LongArray): jlongArray? {
 }
 
 @OptIn(ExperimentalForeignApi::class)
-fun LongArray.toJLongArray(env: CPointer<JNIEnvVar>): jlongArray? {
-    return env.newLongArray(size)?.fill(env, this)
+fun LongArray.toJLongArray(env: CPointer<JNIEnvVar>): jlongArray {
+    return env.newLongArray(size).fill(env, this)
 }

--- a/jni/src/nativeMain/kotlin/com/dshatz/kni/utils/ShortUtils.kt
+++ b/jni/src/nativeMain/kotlin/com/dshatz/kni/utils/ShortUtils.kt
@@ -47,14 +47,14 @@ fun jshortArray.toKShortArray(env: CPointer<JNIEnvVar>): ShortArray {
 }
 
 @OptIn(ExperimentalForeignApi::class)
-fun CPointer<JNIEnvVar>.newShortArray(size: jsize): jshortArray? {
-    val method = pointed.pointedCommon?.NewShortArray ?: return null
-    return method.invoke(this, size)
+fun CPointer<JNIEnvVar>.newShortArray(size: jsize): jshortArray {
+    val method = pointed.pointedCommon?.NewShortArray ?: throw JniUnavailableError()
+    return method.invoke(this, size) ?: throw OutOfMemoryError("Failed to allocate JVM short array of size $size")
 }
 
 @OptIn(ExperimentalForeignApi::class)
-fun jshortArray.fill(env: CPointer<JNIEnvVar>, value: ShortArray): jshortArray? {
-    val method = env.pointed.pointedCommon?.SetShortArrayRegion ?: return null
+fun jshortArray.fill(env: CPointer<JNIEnvVar>, value: ShortArray): jshortArray {
+    val method = env.pointed.pointedCommon?.SetShortArrayRegion ?: throw JniUnavailableError()
     value.usePinned {
         val pointer = it.addressOf(0)
         method.invoke(env, this, 0, value.size, pointer)
@@ -63,6 +63,6 @@ fun jshortArray.fill(env: CPointer<JNIEnvVar>, value: ShortArray): jshortArray? 
 }
 
 @OptIn(ExperimentalForeignApi::class)
-fun ShortArray.toJShortArray(env: CPointer<JNIEnvVar>): jshortArray? {
-    return env.newShortArray(size)?.fill(env, this)
+fun ShortArray.toJShortArray(env: CPointer<JNIEnvVar>): jshortArray {
+    return env.newShortArray(size).fill(env, this)
 }

--- a/jni/src/nativeMain/kotlin/com/dshatz/kni/utils/ShortUtils.kt
+++ b/jni/src/nativeMain/kotlin/com/dshatz/kni/utils/ShortUtils.kt
@@ -7,6 +7,7 @@ import com.dshatz.kni.binding.jshortArray
 import com.dshatz.kni.binding.jshortVar
 import com.dshatz.kni.binding.jint
 import com.dshatz.kni.binding.jsize
+import com.dshatz.kni.error.JniUnavailableError
 import com.dshatz.kni.pointedCommon
 import kotlinx.cinterop.CPointer
 import kotlinx.cinterop.ExperimentalForeignApi
@@ -19,9 +20,9 @@ import kotlinx.cinterop.usePinned
 
 @OptIn(ExperimentalForeignApi::class)
 @RequiresRelease
-fun jshortArray.getShortElements(env: CPointer<JNIEnvVar>, isCopy: CPointer<jbooleanVar>? = null): CPointer<jshortVar>? {
-    val method = env.pointed.pointedCommon?.GetShortArrayElements ?: return null
-    return method.invoke(env, this, isCopy)
+fun jshortArray.getShortElements(env: CPointer<JNIEnvVar>, isCopy: CPointer<jbooleanVar>? = null): CPointer<jshortVar> {
+    val method = env.pointed.pointedCommon?.GetShortArrayElements ?: throw JniUnavailableError()
+    return method.invoke(env, this, isCopy) ?: throw OutOfMemoryError("Failed to call GetShortArrayElements")
 }
 
 @OptIn(ExperimentalForeignApi::class)
@@ -31,9 +32,9 @@ fun jshortArray.releaseElements(env: CPointer<JNIEnvVar>, elements: CPointer<jsh
 }
 
 @OptIn(ExperimentalForeignApi::class, RequiresRelease::class)
-fun jshortArray.toKShortArray(env: CPointer<JNIEnvVar>): ShortArray? {
-    val length = this.getLength(env) ?: return null
-    val elements = this.getShortElements(env) ?: return null
+fun jshortArray.toKShortArray(env: CPointer<JNIEnvVar>): ShortArray {
+    val length = this.getLength(env)
+    val elements = this.getShortElements(env)
 
     val result = memScoped {
         ShortArray(length) {


### PR DESCRIPTION
## The issue: 
In 2.2.0, the generated native code assigns the return values of toKByteArray and toKLongArray to non-nullable variables. However, the actual return types of these two methods are marked as nullable, leading to type-mismatch compilation errors.

## The fix:
Change the return types of toKByteArray and toKLongArray to non-nullable (ByteArray and LongArray) to match the generated native binding code.

<img width="854" height="259" alt="image" src="https://github.com/user-attachments/assets/7667b90c-7d7b-403f-8d9e-61288f9ba792" />
